### PR TITLE
ci: add build pipeline using Azure Pipelines

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -1,0 +1,186 @@
+# Build pipeline for 'https://github.com/Sjofartsdirektoratet/NLP_PoC'
+
+name: nlp.$(Date:yyyMMdd)$(Rev:.r)
+
+trigger:
+  branches:
+    include:
+      - master
+
+pr:
+  - master
+
+pool:
+  vmImage: ubuntu-20.04
+
+stages:
+  - stage: build_and_push
+
+    variables:
+      - group: ET - Common
+      - group: ET - Services
+
+      - name: DOCKER_BUILDKIT
+        value: 1
+
+    jobs:
+      - job: servicecontroller
+
+        variables:
+          dockerRepo: et/nlpservicecontroller
+
+        steps:
+          - bash: |
+              docker build -f ServiceController.ControllerApi/Dockerfile \
+                -t "sdirhacrcommon.azurecr.io/$(dockerRepo):$(Build.BuildId)" \
+                -t "sdirhacrcommon.azurecr.io/$(dockerRepo):$(Build.SourceVersion)" \
+                --build-arg ACCESS_TOKEN \
+                .
+            displayName: Docker Build
+            env:
+              ACCESS_TOKEN: $(ACCESS_TOKEN)
+            workingDirectory: ServiceController/ServiceController
+
+          - task: Docker@2
+            displayName: Docker Push
+            inputs:
+              command: push
+              containerRegistry: Sdir ACR
+              repository: "$(dockerRepo)"
+              tags: |
+                $(Build.BuildId)
+                $(Build.SourceVersion)
+
+      - job: nlpapi
+
+        variables:
+          dockerRepo: et/nlpapi
+
+        steps:
+          - bash: |
+              docker build \
+                -t "sdirhacrcommon.azurecr.io/$(dockerRepo):$(Build.BuildId)" \
+                -t "sdirhacrcommon.azurecr.io/$(dockerRepo):$(Build.SourceVersion)" \
+                 .
+            displayName: Docker Build
+            env:
+              ACCESS_TOKEN: $(ACCESS_TOKEN)
+            workingDirectory: NLP-Flask-Api
+
+          - task: Docker@2
+            displayName: Docker Push
+            inputs:
+              command: push
+              containerRegistry: Sdir ACR
+              repository: "$(dockerRepo)"
+              tags: |
+                $(Build.BuildId)
+                $(Build.SourceVersion)
+
+      - job: rdftransformer
+
+        variables:
+          dockerRepo: et/rdftransformer
+
+        steps:
+          - bash: |
+              docker build \
+                -t "sdirhacrcommon.azurecr.io/$(dockerRepo):$(Build.BuildId)" \
+                -t "sdirhacrcommon.azurecr.io/$(dockerRepo):$(Build.SourceVersion)" \
+                .
+            displayName: Docker Build
+            env:
+              ACCESS_TOKEN: $(ACCESS_TOKEN)
+            workingDirectory: rdf-transformer
+
+          - task: Docker@2
+            displayName: Docker Push
+            inputs:
+              command: push
+              containerRegistry: Sdir ACR
+              repository: "$(dockerRepo)"
+              tags: |
+                $(Build.BuildId)
+                $(Build.SourceVersion)
+
+  - stage: terraform_plan_test
+
+    variables:
+      - group: ET - Common
+      - group: ET - Kubernetes
+      - group: ET - NLP
+      - group: ET - Dev
+
+    jobs:
+      - job: terraform_plan_test
+        steps:
+
+        - task: CopyFiles@2
+          displayName: "Artifact: add terraform to staging"
+          inputs:
+            sourceFolder: terraform
+            contents: "**"
+            targetFolder: "$(Build.ArtifactStagingDirectory)/terraform"
+
+        - bash: |
+            set -eo pipefail
+
+            echo -e "\n\nLoggin in to Azure...\n\n"
+            az login --service-principal -u "$ARM_CLIENT_ID" -p "$ARM_CLIENT_SECRET" --tenant "$ARM_TENANT_ID"
+
+            echo -e "\n\nSet working subscription to $ENVIRONMENT...\n\n"
+            az account set --subscription "$ARM_SUBSCRIPTION_ID"
+
+            echo -e "\n\nCreate storage container for tf state...\n\n"
+            az storage container create --name "$AZ_TF_STORAGE_CONTAINER_NAME" --account-name "$AZ_TF_STORAGE_NAME"
+
+            echo -e "\n\nSet AZ_TF_STORAGE_KEY variable...\n\n"
+            key=$(az storage account keys list -o tsv \
+              --resource-group "$AZ_RESOURCE_GROUP" \
+              --account-name "$AZ_TF_STORAGE_NAME" \
+              --query "[?keyName == 'key1'].value | [0]")
+            echo "##vso[task.setvariable variable=AZ_TF_STORAGE_KEY;issecret=true]$key"
+          displayName: "System: prepare environment for terraform"
+          env:
+            ARM_CLIENT_SECRET: $(ARM_CLIENT_SECRET)
+
+        - bash: |
+            terraform -v &&
+            terraform init --input=false \
+              --backend-config="resource_group_name=$AZ_RESOURCE_GROUP" \
+              --backend-config="storage_account_name=$AZ_TF_STORAGE_NAME" \
+              --backend-config="container_name=$AZ_TF_STORAGE_CONTAINER_NAME" \
+              --backend-config="access_key=$AZ_TF_STORAGE_KEY"
+          displayName: "Terraform: init"
+          workingDirectory: terraform
+          env:
+            ARM_CLIENT_SECRET: $(ARM_CLIENT_SECRET)
+            AZ_TF_STORAGE_KEY: $(AZ_TF_STORAGE_KEY)
+
+        - bash: |
+            terraform validate
+          displayName: "Terraform: validate"
+          workingDirectory: terraform
+          env:
+            ARM_CLIENT_SECRET: $(ARM_CLIENT_SECRET)
+            AZ_TF_STORAGE_KEY: $(AZ_TF_STORAGE_KEY)
+
+        - bash: |
+            terraform plan --input=false --refresh=true --lock=false --out="release.tfplan"
+          displayName: "Terraform: plan"
+          workingDirectory: terraform
+          env:
+            ARM_CLIENT_SECRET: $(ARM_CLIENT_SECRET)
+            AZ_TF_STORAGE_KEY: $(AZ_TF_STORAGE_KEY)
+
+        - bash: |
+            terraform show --json release.tfplan > ../release.json
+          displayName: "Terraform: prepare plan for unit testing"
+          workingDirectory: terraform
+
+        - bash: |
+            docker run --rm -v "$(pwd):/target" -t eerkunt/terraform-compliance --features terraform-test/unit --planfile release.json
+          displayName: "Terraform-compliance: run unit tests"
+
+        - publish: "$(Build.ArtifactStagingDirectory)"
+          artifact: "tfnlp_$(Build.BuildId)"

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -5,10 +5,10 @@ name: nlp.$(Date:yyyMMdd)$(Rev:.r)
 trigger:
   branches:
     include:
-      - master
+      - main
 
 pr:
-  - master
+  - main
 
 pool:
   vmImage: ubuntu-20.04

--- a/terraform-test/unit/namespace.feature
+++ b/terraform-test/unit/namespace.feature
@@ -1,0 +1,12 @@
+Feature: NLP namespace
+  In order to deploy NLP related resources
+  As cloud engineers
+  We require a kubernetes namespace
+
+
+  Scenario: NLP namepsace
+    Given I have kubernetes_namespace defined
+    When its address is kubernetes_namespace.nlp
+    Then it must contain metadata
+    And it must contain name
+    And its value must be "nlp"

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,0 +1,58 @@
+variable "RESOURCE_GROUP" {
+  type = string
+}
+
+variable "ENVIRONMENT" {
+  type = string
+}
+
+variable "ENV" {
+  type = string
+}
+
+variable "AKS_CLUSTER_NAME" {
+  type = string
+}
+
+variable "AZ_KEYVAULT_NAME" {
+  type = string
+}
+
+variable "SECRETS_SP_NAME" {
+  type = string
+}
+
+# Cluster info
+data "azurerm_subscription" "current" {
+}
+
+data "azurerm_kubernetes_cluster" "et" {
+  name                = var.AKS_CLUSTER_NAME
+  resource_group_name = var.RESOURCE_GROUP
+}
+
+# Key Vault where secrets and certificates are stored
+data "azurerm_key_vault" "keyVault" {
+  name                = var.AZ_KEYVAULT_NAME
+  resource_group_name = var.RESOURCE_GROUP
+}
+
+# Service Principal for reading secrets
+data "azuread_service_principal" "secretsServicePrincipal" {
+  display_name = var.SECRETS_SP_NAME
+}
+
+data "azurerm_key_vault_secret" "secretsServicePrincipal" {
+  name         = var.SECRETS_SP_NAME
+  key_vault_id = data.azurerm_key_vault.keyVault.id
+}
+
+locals {
+  common_tags = {
+    Owner       = "Christian Fosli"
+    Application = "ET"
+    Department  = "DevOps"
+    Environment = var.ENVIRONMENT
+    Backup      = "False"
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,46 @@
+terraform {
+  backend "azurerm" {
+    key = "terraform.tfstate"
+  }
+
+  required_providers {
+    azuread = {
+      version = "~>1.4"
+    }
+    azurerm = {
+      version = "~>2.56"
+    }
+    helm = {
+      version = "~>2.1"
+    }
+    kubernetes = {
+      version = "~>2.1"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+provider "helm" {
+  kubernetes {
+    host     = data.azurerm_kubernetes_cluster.et.kube_config.0.host
+    username = data.azurerm_kubernetes_cluster.et.kube_config.0.username
+    password = data.azurerm_kubernetes_cluster.et.kube_config.0.password
+
+    client_certificate     = base64decode(data.azurerm_kubernetes_cluster.et.kube_config.0.client_certificate)
+    client_key             = base64decode(data.azurerm_kubernetes_cluster.et.kube_config.0.client_key)
+    cluster_ca_certificate = base64decode(data.azurerm_kubernetes_cluster.et.kube_config.0.cluster_ca_certificate)
+  }
+}
+
+provider "kubernetes" {
+  host     = data.azurerm_kubernetes_cluster.et.kube_config.0.host
+  username = data.azurerm_kubernetes_cluster.et.kube_config.0.username
+  password = data.azurerm_kubernetes_cluster.et.kube_config.0.password
+
+  client_certificate     = base64decode(data.azurerm_kubernetes_cluster.et.kube_config.0.client_certificate)
+  client_key             = base64decode(data.azurerm_kubernetes_cluster.et.kube_config.0.client_key)
+  cluster_ca_certificate = base64decode(data.azurerm_kubernetes_cluster.et.kube_config.0.cluster_ca_certificate)
+}

--- a/terraform/namespace.tf
+++ b/terraform/namespace.tf
@@ -1,0 +1,5 @@
+resource "kubernetes_namespace" "nlp" {
+  metadata {
+    name = "nlp"
+  }
+}


### PR DESCRIPTION
Adds a build pipeline using Azure Pipelines that pushes docker images to sdir's container registry in azure.
This makes the docker images available to use from kubernetes.

Also adds a terraform module to keep track of deployments for these services.

---

The next PR will add helm charts/kubernetes manifests so that we actually run  these services. This is one is a prerequisite for that.

---

A successful run can be seen [here](https://dev.azure.com/sdir-no/ET/_build/results?buildId=11573&view=results).
This pipeline in Azure DevOps currently tracks my fork, but we can change that once this is merged.